### PR TITLE
Use `url.JoinPath` instead of `filepath.Join` for constructing data plane resource id

### DIFF
--- a/internal/tfid/build_key_vault_storage_account_sas_token_definition.go
+++ b/internal/tfid/build_key_vault_storage_account_sas_token_definition.go
@@ -3,7 +3,6 @@ package tfid
 import (
 	"fmt"
 	"net/url"
-	"path/filepath"
 
 	"github.com/magodo/armid"
 	"github.com/magodo/aztft/internal/client"
@@ -18,6 +17,6 @@ func buildKeyVaultStorageAccountSasTokenDefinition(b *client.ClientBuilder, id a
 	if err != nil {
 		return "", fmt.Errorf("parsing uri %s: %v", storageId, err)
 	}
-	uri.Path = filepath.Join(uri.Path, "sas", id.Names()[2])
+	uri = uri.JoinPath("sas", id.Names()[2])
 	return uri.String(), nil
 }

--- a/internal/tfid/build_storage_build.go
+++ b/internal/tfid/build_storage_build.go
@@ -3,7 +3,6 @@ package tfid
 import (
 	"fmt"
 	"net/url"
-	"path/filepath"
 
 	"github.com/magodo/armid"
 	"github.com/magodo/aztft/internal/client"
@@ -18,6 +17,6 @@ func buildStorageBlob(b *client.ClientBuilder, id armid.ResourceId, spec string)
 	if err != nil {
 		return "", fmt.Errorf("parsing uri %s: %v", containerId, err)
 	}
-	uri.Path = filepath.Join(uri.Path, id.Names()[3])
+	uri = uri.JoinPath(id.Names()[3])
 	return uri.String(), nil
 }

--- a/internal/tfid/build_storage_container.go
+++ b/internal/tfid/build_storage_container.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"path/filepath"
 
 	"github.com/magodo/armid"
 	"github.com/magodo/aztft/internal/client"
@@ -36,6 +35,6 @@ func buildStorageContainer(b *client.ClientBuilder, id armid.ResourceId, spec st
 	if err != nil {
 		return "", fmt.Errorf("failed to parse url %s: %v", *blobEndpoint, err)
 	}
-	uri.Path = filepath.Join(uri.Path, id.Names()[2])
+	uri = uri.JoinPath(id.Names()[2])
 	return uri.String(), nil
 }

--- a/internal/tfid/build_storage_dfs.go
+++ b/internal/tfid/build_storage_dfs.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"path/filepath"
 
 	"github.com/magodo/armid"
 	"github.com/magodo/aztft/internal/client"
@@ -36,6 +35,6 @@ func buildStorageDfs(b *client.ClientBuilder, id armid.ResourceId, spec string) 
 	if err != nil {
 		return "", fmt.Errorf("failed to parse url %s: %v", *dfsEndpoint, err)
 	}
-	uri.Path = filepath.Join(uri.Path, id.Names()[1])
+	uri = uri.JoinPath(id.Names()[1])
 	return uri.String(), nil
 }

--- a/internal/tfid/build_storage_dfs_path.go
+++ b/internal/tfid/build_storage_dfs_path.go
@@ -3,7 +3,6 @@ package tfid
 import (
 	"fmt"
 	"net/url"
-	"path/filepath"
 	"strings"
 
 	"github.com/magodo/armid"
@@ -21,6 +20,6 @@ func buildStorageDfsPath(b *client.ClientBuilder, id armid.ResourceId, spec stri
 	}
 	path := id.Names()[2]
 	path = strings.ReplaceAll(path, ":", "/")
-	uri.Path = filepath.Join(uri.Path, path)
+	uri = uri.JoinPath(path)
 	return uri.String(), nil
 }

--- a/internal/tfid/build_storage_queue.go
+++ b/internal/tfid/build_storage_queue.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"path/filepath"
 
 	"github.com/magodo/armid"
 	"github.com/magodo/aztft/internal/client"
@@ -36,6 +35,6 @@ func buildStorageQueue(b *client.ClientBuilder, id armid.ResourceId, spec string
 	if err != nil {
 		return "", fmt.Errorf("failed to parse url %s: %v", *queueEndpoint, err)
 	}
-	uri.Path = filepath.Join(uri.Path, id.Names()[2])
+	uri = uri.JoinPath(id.Names()[2])
 	return uri.String(), nil
 }

--- a/internal/tfid/build_storage_share.go
+++ b/internal/tfid/build_storage_share.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"path/filepath"
 
 	"github.com/magodo/armid"
 	"github.com/magodo/aztft/internal/client"
@@ -36,6 +35,6 @@ func buildStorageShare(b *client.ClientBuilder, id armid.ResourceId, spec string
 	if err != nil {
 		return "", fmt.Errorf("failed to parse url %s: %v", *fileEndpoint, err)
 	}
-	uri.Path = filepath.Join(uri.Path, id.Names()[2])
+	uri = uri.JoinPath(id.Names()[2])
 	return uri.String(), nil
 }

--- a/internal/tfid/build_storage_share_directory.go
+++ b/internal/tfid/build_storage_share_directory.go
@@ -3,7 +3,6 @@ package tfid
 import (
 	"fmt"
 	"net/url"
-	"path/filepath"
 	"strings"
 
 	"github.com/magodo/armid"
@@ -21,6 +20,6 @@ func buildStorageShareDirectory(b *client.ClientBuilder, id armid.ResourceId, sp
 	}
 	path := id.Names()[3]
 	path = strings.ReplaceAll(path, ":", "/")
-	uri.Path = filepath.Join(uri.Path, path)
+	uri = uri.JoinPath(path)
 	return uri.String(), nil
 }

--- a/internal/tfid/build_storage_share_file.go
+++ b/internal/tfid/build_storage_share_file.go
@@ -3,7 +3,6 @@ package tfid
 import (
 	"fmt"
 	"net/url"
-	"path/filepath"
 	"strings"
 
 	"github.com/magodo/armid"
@@ -21,6 +20,6 @@ func buildStorageShareFile(b *client.ClientBuilder, id armid.ResourceId, spec st
 	}
 	path := id.Names()[3]
 	path = strings.ReplaceAll(path, ":", "/")
-	uri.Path = filepath.Join(uri.Path, path)
+	uri = uri.JoinPath(path)
 	return uri.String(), nil
 }


### PR DESCRIPTION
Fix #4 