### PR TITLE
update to go1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/magodo/aztft
 
-go 1.18
+go 1.19
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0


### PR DESCRIPTION
`url.JoinPath` is added since go `1.19`, so update `go.mod`
- https://github.com/golang/go/commit/604140d93111f89911e17cb147dcf6a02d2700d0