### PR TITLE
Support logic app workflow action/trigger

### DIFF
--- a/aztft/aztft.go
+++ b/aztft/aztft.go
@@ -107,64 +107,52 @@ func queryType(idStr string, apiOpt *APIOption) ([]Type, bool, error) {
 		return nil, false, fmt.Errorf("invalid resource id: %v", err)
 	}
 
-	l := getARMId2TFMapItems(id)
-	if len(l) == 0 {
-		return nil, false, nil
-	}
+	var (
+		result []Type
+		exact  bool
+	)
 
-	var result []Type
-
-	exact := len(l) == 1
-	if apiOpt != nil {
-		// Resolve ambiguous resources
-		if len(l) > 1 {
-			rt, err := resolve.Resolve(id, apiOpt.Cred, apiOpt.ClientOption)
-			if err != nil {
-				return nil, false, err
-			}
-			for _, item := range l {
-				if item.ResourceType == rt {
-					l = []resmap.ARMId2TFMapItem{item}
-					break
-				}
-			}
-			if len(l) > 1 {
-				return nil, false, fmt.Errorf("the ambiguity list doesn't have an item with resource type %q, please open an issue for this", rt)
-			}
+	if apiOpt == nil {
+		l := getARMId2TFMapItems(id)
+		if len(l) == 0 {
+			return nil, false, nil
 		}
 
+		exact = len(l) == 1
+		for _, item := range l {
+			result = append(result, Type{
+				AzureId: id,
+				TFType:  item.ResourceType,
+			})
+		}
+	} else {
+		entry, err := mapEntryById(id, *apiOpt)
+		if err != nil {
+			return nil, false, fmt.Errorf("mapping entry by id %s: %v", id, err)
+		}
 		// There must be only one resource type, try to populate any property like resources for it.
 		exact = true
 		result = []Type{
 			{
 				AzureId: id,
-				TFType:  l[0].ResourceType,
+				TFType:  entry.ResourceType,
 			},
 		}
 
-		rt := l[0].ResourceType
+		rt := entry.ResourceType
 		propLikeResIds, err := populate.Populate(id, rt, apiOpt.Cred, apiOpt.ClientOption)
 		if err != nil {
 			return nil, false, fmt.Errorf("populating property-like resources for %s: %v", rt, err)
 		}
 
 		for _, propLikeResId := range propLikeResIds {
-			tmpl := getARMId2TFMapItems(propLikeResId)
-			// The resource id of property like resources are hypothetic "unique" resource id, they should have no ambiguity. Otherwise, it is a bug.
-			if len(tmpl) != 1 {
-				return nil, false, fmt.Errorf("expect 1 TF resource matched for resource id %q, but got %d. Please open an issue for this", propLikeResId, len(tmpl))
+			entry, err := mapEntryById(propLikeResId, *apiOpt)
+			if err != nil {
+				return nil, false, fmt.Errorf("mapping entry by id %s: %v", id, err)
 			}
-			item := tmpl[0]
 			result = append(result, Type{
 				AzureId: propLikeResId,
-				TFType:  item.ResourceType,
-			})
-		}
-	} else {
-		for _, item := range l {
-			result = append(result, Type{
-				AzureId: id,
-				TFType:  item.ResourceType,
+				TFType:  entry.ResourceType,
 			})
 		}
 	}
@@ -177,4 +165,28 @@ func queryType(idStr string, apiOpt *APIOption) ([]Type, bool, error) {
 	})
 
 	return result, exact, nil
+}
+
+func mapEntryById(id armid.ResourceId, apiOpt APIOption) (*resmap.ARMId2TFMapItem, error) {
+	l := getARMId2TFMapItems(id)
+	if len(l) == 0 {
+		return nil, nil
+	}
+	// Resolve ambiguous resources
+	if len(l) > 1 {
+		rt, err := resolve.Resolve(id, apiOpt.Cred, apiOpt.ClientOption)
+		if err != nil {
+			return nil, err
+		}
+		for _, item := range l {
+			if item.ResourceType == rt {
+				l = []resmap.ARMId2TFMapItem{item}
+				break
+			}
+		}
+		if len(l) > 1 {
+			return nil, fmt.Errorf("the ambiguity list doesn't have an item with resource type %q", rt)
+		}
+	}
+	return &l[0], nil
 }

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hdinsight/armhdinsight v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/kusto/armkusto v1.0.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/logic/armlogic v1.1.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v3 v3.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.0.
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.0.0/go.mod h1:PFVgFsclKzPqYRT/BiwpfUN22cab0C7FlgXR3iWpwMo=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/kusto/armkusto v1.0.0 h1:W2zaZM9yMaYNbd9PrVzwlFew6ZjNw11Yj6ruhfB7s+U=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/kusto/armkusto v1.0.0/go.mod h1:jvGYrB34pAXYIswdCsfFmWfhEChz7vyWhArzNPYKdsw=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/logic/armlogic v1.1.1 h1:YqPDzajLbEGiIr1wbj0AINMj54q3LtWzfwASAMGklAQ=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/logic/armlogic v1.1.1/go.mod h1:DwT51rZDyLryjioY2lt18MlJ8risPJlt8HaKdciJlMI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v3 v3.0.0 h1:C8jlM/kxDVoUbmPJPp0C6Tz8VfiuAe+Lwcdw2DeyRPE=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v3 v3.0.0/go.mod h1:6IMUN/Qwv/Y6aL21XxWGcQXfRYrivO4qFPWsbf0wVJI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.7.0 h1:U6aSmNaC/WWDlHnL0e+SxQlvYmcjdoBLFjNir8AZBe0=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hdinsight/armhdinsight"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/kusto/armkusto"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/logic/armlogic"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v3"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
@@ -583,6 +584,14 @@ func (b *ClientBuilder) NewCostManagementScheduledActionsClient() (*armcostmanag
 
 func (b *ClientBuilder) NewApplicationInsightsWebTestsClient(subscriptionId string) (*armapplicationinsights.WebTestsClient, error) {
 	return armapplicationinsights.NewWebTestsClient(
+		subscriptionId,
+		b.Cred,
+		&b.ClientOpt,
+	)
+}
+
+func (b *ClientBuilder) NewLogicWorkflowsClient(subscriptionId string) (*armlogic.WorkflowsClient, error) {
+	return armlogic.NewWorkflowsClient(
 		subscriptionId,
 		b.Cred,
 		&b.ClientOpt,

--- a/internal/populate/populate.go
+++ b/internal/populate/populate.go
@@ -19,6 +19,7 @@ var populaters = map[string]populateFunc{
 	"azurerm_disk_pool":                 populateDiskPool,
 	"azurerm_disk_pool_iscsi_target":    populateDiskPoolIscsiTarget,
 	"azurerm_subnet":                    populateSubnet,
+	"azurerm_logic_app_workflow":        populateLogicAppWorkflow,
 }
 
 func NeedsAPI(rt string) bool {

--- a/internal/populate/populate_logic_workflow.go
+++ b/internal/populate/populate_logic_workflow.go
@@ -1,0 +1,55 @@
+package populate
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/magodo/armid"
+	"github.com/magodo/aztft/internal/client"
+)
+
+func populateLogicAppWorkflow(b *client.ClientBuilder, id armid.ResourceId) ([]armid.ResourceId, error) {
+	resourceGroupId := id.RootScope().(*armid.ResourceGroup)
+	client, err := b.NewLogicWorkflowsClient(resourceGroupId.SubscriptionId)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Get(context.Background(), resourceGroupId.Name, id.Names()[0], nil)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %q: %v", id, err)
+	}
+	props := resp.Workflow.Properties
+	if props == nil {
+		return nil, nil
+	}
+
+	if props.Definition == nil {
+		return nil, nil
+	}
+
+	def := props.Definition.(map[string]interface{})
+
+	var result []armid.ResourceId
+
+	if actionsRaw, ok := def["actions"]; ok {
+		actions := actionsRaw.(map[string]interface{})
+		for name := range actions {
+			azureId := id.Clone().(*armid.ScopedResourceId)
+			azureId.AttrTypes = append(azureId.AttrTypes, "actions")
+			azureId.AttrNames = append(azureId.AttrNames, name)
+			result = append(result, azureId)
+		}
+	}
+
+	if triggersRaw, ok := def["triggers"]; ok {
+		triggers := triggersRaw.(map[string]interface{})
+		for name := range triggers {
+			azureId := id.Clone().(*armid.ScopedResourceId)
+			azureId.AttrTypes = append(azureId.AttrTypes, "triggers")
+			azureId.AttrNames = append(azureId.AttrNames, name)
+			result = append(result, azureId)
+		}
+	}
+
+	return result, nil
+}

--- a/internal/resmap/map.json
+++ b/internal/resmap/map.json
@@ -6976,8 +6976,6 @@
     }
   },
   "azurerm_logic_app_action_custom": {
-    "is_removed": true,
-    "remove_reason": "This is a property rather than a resource",
     "management_plane": {
       "scopes": [
         "/subscriptions/resourceGroups"
@@ -6993,8 +6991,6 @@
     }
   },
   "azurerm_logic_app_action_http": {
-    "is_removed": true,
-    "remove_reason": "This is a property rather than a resource",
     "management_plane": {
       "scopes": [
         "/subscriptions/resourceGroups"
@@ -7158,8 +7154,6 @@
     }
   },
   "azurerm_logic_app_trigger_custom": {
-    "is_removed": true,
-    "remove_reason": "This is a property rather than a resource",
     "management_plane": {
       "scopes": [
         "/subscriptions/resourceGroups"
@@ -7175,8 +7169,6 @@
     }
   },
   "azurerm_logic_app_trigger_http_request": {
-    "is_removed": true,
-    "remove_reason": "This is a property rather than a resource",
     "management_plane": {
       "scopes": [
         "/subscriptions/resourceGroups"
@@ -7192,8 +7184,6 @@
     }
   },
   "azurerm_logic_app_trigger_recurrence": {
-    "is_removed": true,
-    "remove_reason": "This is a property rather than a resource",
     "management_plane": {
       "scopes": [
         "/subscriptions/resourceGroups"

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -184,6 +184,12 @@ var Resolvers = map[string]map[string]resolver{
 	"/MICROSOFT.INSIGHTS/WEBTESTS": {
 		"/SUBSCRIPTIONS/RESOURCEGROUPS": applicationInsightsWebTestsResolver{},
 	},
+	"/MICROSOFT.LOGIC/WORKFLOWS/ACTIONS": {
+		"/SUBSCRIPTIONS/RESOURCEGROUPS": logicAppAction{},
+	},
+	"/MICROSOFT.LOGIC/WORKFLOWS/TRIGGERS": {
+		"/SUBSCRIPTIONS/RESOURCEGROUPS": logicAppTrigger{},
+	},
 }
 
 type ResolveError struct {

--- a/internal/resolve/resolve_logic_app_action.go
+++ b/internal/resolve/resolve_logic_app_action.go
@@ -1,0 +1,63 @@
+package resolve
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/magodo/armid"
+	"github.com/magodo/aztft/internal/client"
+)
+
+type logicAppAction struct{}
+
+func (logicAppAction) ResourceTypes() []string {
+	return []string{"azurerm_logic_app_action_custom", "azurerm_logic_app_action_http"}
+}
+
+func (logicAppAction) Resolve(b *client.ClientBuilder, id armid.ResourceId) (string, error) {
+	resourceGroupId := id.RootScope().(*armid.ResourceGroup)
+	client, err := b.NewLogicWorkflowsClient(resourceGroupId.SubscriptionId)
+	if err != nil {
+		return "", err
+	}
+	resp, err := client.Get(context.Background(), resourceGroupId.Name, id.Names()[0], nil)
+	if err != nil {
+		return "", fmt.Errorf("retrieving %q: %v", id, err)
+	}
+	props := resp.Workflow.Properties
+	if props == nil {
+		return "", fmt.Errorf("unexpected nil property in response")
+	}
+
+	type Def struct {
+		Actions map[string]struct {
+			Type string
+		}
+	}
+
+	rb, err := json.Marshal(props.Definition)
+	if err != nil {
+		return "", fmt.Errorf("marshaling definition: %v", err)
+	}
+	var def Def
+	if err := json.Unmarshal(rb, &def); err != nil {
+		return "", fmt.Errorf("unmarshaling definition: %v", err)
+	}
+
+	if len(def.Actions) == 0 {
+		return "", fmt.Errorf("unexpected nil actions")
+	}
+
+	action, ok := def.Actions[id.Names()[1]]
+	if !ok {
+		return "", fmt.Errorf("can't find action with name %s", id.Names()[1])
+	}
+	switch strings.ToLower(action.Type) {
+	case "http":
+		return "azurerm_logic_app_action_http", nil
+	default:
+		return "azurerm_logic_app_action_custom", nil
+	}
+}

--- a/internal/resolve/resolve_logic_app_trigger.go
+++ b/internal/resolve/resolve_logic_app_trigger.go
@@ -1,0 +1,65 @@
+package resolve
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/magodo/armid"
+	"github.com/magodo/aztft/internal/client"
+)
+
+type logicAppTrigger struct{}
+
+func (logicAppTrigger) ResourceTypes() []string {
+	return []string{"azurerm_logic_app_trigger_recurrence", "azurerm_logic_app_trigger_custom", "azurerm_logic_app_trigger_http_request"}
+}
+
+func (logicAppTrigger) Resolve(b *client.ClientBuilder, id armid.ResourceId) (string, error) {
+	resourceGroupId := id.RootScope().(*armid.ResourceGroup)
+	client, err := b.NewLogicWorkflowsClient(resourceGroupId.SubscriptionId)
+	if err != nil {
+		return "", err
+	}
+	resp, err := client.Get(context.Background(), resourceGroupId.Name, id.Names()[0], nil)
+	if err != nil {
+		return "", fmt.Errorf("retrieving %q: %v", id, err)
+	}
+	props := resp.Workflow.Properties
+	if props == nil {
+		return "", fmt.Errorf("unexpected nil property in response")
+	}
+
+	type Def struct {
+		Triggers map[string]struct {
+			Type string
+		}
+	}
+
+	rb, err := json.Marshal(props.Definition)
+	if err != nil {
+		return "", fmt.Errorf("marshaling definition: %v", err)
+	}
+	var def Def
+	if err := json.Unmarshal(rb, &def); err != nil {
+		return "", fmt.Errorf("unmarshaling definition: %v", err)
+	}
+
+	if len(def.Triggers) == 0 {
+		return "", fmt.Errorf("unexpected nil triggers")
+	}
+
+	trigger, ok := def.Triggers[id.Names()[1]]
+	if !ok {
+		return "", fmt.Errorf("can't find trigger with name %s", id.Names()[1])
+	}
+	switch strings.ToLower(trigger.Type) {
+	case "request":
+		return "azurerm_logic_app_trigger_http_request", nil
+	case "recurrence":
+		return "azurerm_logic_app_trigger_recurrence", nil
+	default:
+		return "azurerm_logic_app_trigger_custom", nil
+	}
+}


### PR DESCRIPTION
Using the following TF config to create resources:

```
provider "azurerm" {
  features {
    resource_group {
      prevent_deletion_if_contains_resources = false
    }
  }
}
resource "azurerm_resource_group" "test" {
  name     = "acctestRG-230704110610860336"
  location = "WestEurope"
}
resource "azurerm_logic_app_workflow" "test" {
  name                = "acctestlaw-230704110610860336"
  location            = azurerm_resource_group.test.location
  resource_group_name = azurerm_resource_group.test.name
}
resource "azurerm_logic_app_action_custom" "test" {
  name         = "action230704110610860336"
  logic_app_id = azurerm_logic_app_workflow.test.id
  body         = <<BODY
{
    "description": "A variable to configure the auto expiration age in days. Configured in negative number. Default is -30 (30 days old).",
    "inputs": {
        "variables": [
            {
                "name": "ExpirationAgeInDays",
                "type": "Integer",
                "value": -30
            }
        ]
    },
    "runAfter": {},
    "type": "InitializeVariable"
}
BODY
}

resource "azurerm_logic_app_action_http" "test" {
  name         = "action230704112918798360"
  logic_app_id = azurerm_logic_app_workflow.test.id
  method       = "GET"
  uri          = "http://example.com/hello"
}

resource "azurerm_logic_app_trigger_custom" "test" {
  name         = "recurrence-123123"
  logic_app_id = azurerm_logic_app_workflow.test.id

  body = <<BODY
{
  "recurrence": {
    "frequency": "Day",
    "interval": 1
  },
  "type": "Recurrence"
}
BODY

}

resource "azurerm_logic_app_trigger_recurrence" "test" {
  name         = "frequency-trigger"
  logic_app_id = azurerm_logic_app_workflow.test.id
  frequency    = "Week"
  interval     = 1
}

resource "azurerm_logic_app_trigger_http_request" "test" {
  name         = "some-http-trigger"
  logic_app_id = azurerm_logic_app_workflow.test.id
  schema       = "{}"
}
```

This includes:

- azurerm_logic_app_action_custom.test
- azurerm_logic_app_action_http.test
- azurerm_logic_app_trigger_custom.test
- azurerm_logic_app_trigger_http_request.test
- azurerm_logic_app_trigger_recurrence.test
- azurerm_logic_app_workflow.test
- azurerm_resource_group.test

Then using `aztft` to find the TF resource type and import spec for the `azurerm_logic_app_workflow` and its property-like resources:

```
$ aztft -import -api /subscriptions/****/resourceGroups/acctestRG-230704110610860336/providers/Microsoft.Logic/workflows/acctestlaw-230704110610860336
terraform import azurerm_logic_app_workflow.example /subscriptions/****/resourceGroups/acctestRG-230704110610860336/providers/Microsoft.Logic/workflows/acctestlaw-230704110610860336
terraform import azurerm_logic_app_action_custom.example /subscriptions/****/resourceGroups/acctestRG-230704110610860336/providers/Microsoft.Logic/workflows/acctestlaw-230704110610860336/actions/action230704110610860336
terraform import azurerm_logic_app_action_http.example /subscriptions/****/resourceGroups/acctestRG-230704110610860336/providers/Microsoft.Logic/workflows/acctestlaw-230704110610860336/actions/action230704112918798360
terraform import azurerm_logic_app_trigger_recurrence.example /subscriptions/****/resourceGroups/acctestRG-230704110610860336/providers/Microsoft.Logic/workflows/acctestlaw-230704110610860336/triggers/frequency-trigger
terraform import azurerm_logic_app_trigger_recurrence.example /subscriptions/****/resourceGroups/acctestRG-230704110610860336/providers/Microsoft.Logic/workflows/acctestlaw-230704110610860336/triggers/recurrence-123123
terraform import azurerm_logic_app_trigger_http_request.example /subscriptions/****/resourceGroups/acctestRG-230704110610860336/providers/Microsoft.Logic/workflows/acctestlaw-230704110610860336/triggers/some-http-trigger
```

Note that the `azurerm_logic_app_trigger_custom` is also exported as `azurerm_logic_app_trigger_recurrence` as we prefer `azurerm_logic_app_trigger_recurrence` than the custom one.